### PR TITLE
fix: add header needed for newer g++ version

### DIFF
--- a/MESH/CSRC/mesh_grid.h
+++ b/MESH/CSRC/mesh_grid.h
@@ -7,6 +7,7 @@
 #define MESH_GRID_H
 
 #include <cstdio>
+#include <cstdint>
 #include "meshbase.h"
 
 // Describe directions of presence of PML elements


### PR DESCRIPTION
Add missing header needed to compile with gcc 14